### PR TITLE
This commit adds support for two child views to interact with eachother

### DIFF
--- a/novoda-constraints/Classes/Support.swift
+++ b/novoda-constraints/Classes/Support.swift
@@ -28,21 +28,18 @@ public extension UIView {
                                             attribute: otherEdge,
                                             multiplier: multiplier,
                                             constant: constant)
+        
         constraint.priority = priority
         
-        guard let view = view else {
+        guard let view = view, self != view.superview else { // If other view doesn't exist or self is not the parent, self owns constraint
             addConstraint(constraint)
             return constraint
         }
         
-        if self == view.superview {
-            view.superview?.addConstraint(constraint)
-            
-        } else if view.superview == superview {
-            superview?.addConstraint(constraint) // If common superview, this should own the constraint
-            
+        if view.superview == superview { // If common superview, parent should own the constraint
+            superview?.addConstraint(constraint)
         } else {
-            view.addConstraint(constraint)
+            view.addConstraint(constraint) // In all other cases, other view owns constraint
         }
         
         return constraint


### PR DESCRIPTION
There is currently a huge flaw in how we pin views together; currently the views own their own constraints but the superview MUST own its children's constraints otherwise we result in a fatal crash.

To counteract this we can check if either of the interacting views have a common superview and if so, use this superview to own the constraints