### PR TITLE
Updating library to minimum iOS 9 + removing availability tags

### DIFF
--- a/Anchor.swift
+++ b/Anchor.swift
@@ -1,6 +1,5 @@
 import UIKit
 
-@available(iOS 9.0, *)
 public struct Anchor {
     public let constrain: (UIView, CGFloat) -> Void
     

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -548,7 +548,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/novoda-constraints/novoda-constraints-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/novoda-constraints/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/novoda-constraints/novoda-constraints.modulemap";
 				PRODUCT_NAME = novoda_constraints;
@@ -612,7 +612,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/novoda-constraints/novoda-constraints-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/novoda-constraints/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/novoda-constraints/novoda-constraints.modulemap";
 				PRODUCT_NAME = novoda_constraints;

--- a/novoda-constraints.podspec
+++ b/novoda-constraints.podspec
@@ -28,7 +28,7 @@ TODO: Add long description of the pod here.
   s.source           = { :git => 'https://github.com/novoda/novoda-constraints.git', :tag => s.version.to_s }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
 
   s.source_files = 'novoda-constraints/Classes/**/*'
   

--- a/novoda-constraints/Classes/UIView+Anchors.swift
+++ b/novoda-constraints/Classes/UIView+Anchors.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-@available(iOS 9.0, *)
 extension UIView {
 
     var leadingSafeAnchor: NSLayoutXAxisAnchor {

--- a/novoda-constraints/Classes/UIView+SafeAreas.swift
+++ b/novoda-constraints/Classes/UIView+SafeAreas.swift
@@ -1,6 +1,5 @@
 import UIKit
 
-@available(iOS 9.0, *)
 public extension UIView {
     
     func pin(toSuperviewSafeArea edges: [Anchor],


### PR DESCRIPTION
I think the project should face a minimum target of iOS 9

Reading the [Apple statistics](https://developer.apple.com/support/app-store/) only 8% of devices are below iOS 11, indicating much less for iOS 8.
