### PR TITLE
Applying inset multiplier to constraints

### DIFF
--- a/novoda-constraints/Classes/Support.swift
+++ b/novoda-constraints/Classes/Support.swift
@@ -49,7 +49,7 @@ public extension UIView {
         return pin(edge.layoutAttribute,
                    to: otherEdge.layoutAttribute,
                    of: view,
-                   constant: constant,
+                   constant: edge.offset(equivalentToInset: constant),
                    multiplier: multiplier,
                    priority: priority,
                    relatedBy: relation)


### PR DESCRIPTION
This PR adds the inset multiplier to views that are pinned together.

Prior to this PR when a view is pinned to its superview via its trailing/bottom constraints it has the incorrect result 

i.e. View ends up outside the superview on the trailing/bottom rather than inside it when pinning to all edges with an inset of 8