### PR TITLE
Ensures translatesAutoresizingMaskIntoConstraints is never applied to root view

### DIFF
--- a/novoda-constraints/Classes/Support.swift
+++ b/novoda-constraints/Classes/Support.swift
@@ -6,8 +6,8 @@ public extension UIView {
         guard let superview = self.superview else {
             fatalError("view doesn't have a superview")
         }
-        if superview.superview != nil {
-            superview.translatesAutoresizingMaskIntoConstraints = false
+        guard !(superview is UITableViewCell), !(superview is UICollectionViewCell) else {
+            return
         }
         translatesAutoresizingMaskIntoConstraints = false
     }

--- a/novoda-constraints/Classes/Support.swift
+++ b/novoda-constraints/Classes/Support.swift
@@ -3,11 +3,8 @@ import UIKit
 public extension UIView {
     
     internal func prepareForConstraints() {
-        guard let superview = self.superview else {
+        guard let _ = self.superview else {
             fatalError("view doesn't have a superview")
-        }
-        guard !(superview is UITableViewCell), !(superview is UICollectionViewCell) else {
-            return
         }
         translatesAutoresizingMaskIntoConstraints = false
     }

--- a/novoda-constraints/Classes/Support.swift
+++ b/novoda-constraints/Classes/Support.swift
@@ -3,8 +3,11 @@ import UIKit
 public extension UIView {
     
     internal func prepareForConstraints() {
-        guard let _ = self.superview else {
-            fatalError("view doesn't have a superview")
+        guard let superview = self.superview else {
+            return
+        }
+        guard !(superview is UITableViewCell), !(superview is UICollectionViewCell) else {
+            return
         }
         translatesAutoresizingMaskIntoConstraints = false
     }

--- a/novoda-constraints/Classes/Support.swift
+++ b/novoda-constraints/Classes/Support.swift
@@ -6,7 +6,9 @@ public extension UIView {
         guard let superview = self.superview else {
             fatalError("view doesn't have a superview")
         }
-        superview.translatesAutoresizingMaskIntoConstraints = false
+        if superview.superview != nil {
+            superview.translatesAutoresizingMaskIntoConstraints = false
+        }
         translatesAutoresizingMaskIntoConstraints = false
     }
     
@@ -19,7 +21,6 @@ public extension UIView {
                                          relatedBy relation: NSLayoutConstraint.Relation = .equal) -> NSLayoutConstraint {
         
         prepareForConstraints()
-        view?.translatesAutoresizingMaskIntoConstraints = false
         
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: edge,
@@ -34,6 +35,10 @@ public extension UIView {
         guard let view = view, self != view.superview else { // If other view doesn't exist or self is not the parent, self owns constraint
             addConstraint(constraint)
             return constraint
+        }
+        
+        if view != superview {
+            view.translatesAutoresizingMaskIntoConstraints = false
         }
         
         if view.superview == superview { // If common superview, parent should own the constraint

--- a/novoda-constraints/Classes/UIView+Stack.swift
+++ b/novoda-constraints/Classes/UIView+Stack.swift
@@ -1,10 +1,3 @@
-//
-//  UIView+Stack.swift
-//  novoda-constraints
-//
-//  Created by Simon Rowlands on 08/03/2019.
-//
-
 import Foundation
 
 public extension Array where Element == UIView {


### PR DESCRIPTION
Currently it is a likely scenario that the translatesAutoresizingMaskIntoConstraints property is set to false on a ViewControllers root view; this should not happen as it breaks the UI.

To resolve this two checks have been added:
- One checking whether the superview has a superview (not ideal but it covers the root view)
- One checking whether the view we are pinning to is the superview, if not we can set the translatesAutoresizingMaskIntoConstraints property