### PR TITLE
Adding hierarchy functions + applying to support

### DIFF
--- a/novoda-constraints/Classes/Support.swift
+++ b/novoda-constraints/Classes/Support.swift
@@ -39,21 +39,6 @@ public extension UIView {
 
         view.prepareForConstraints()
 
-        if view.superview == superview { // If we are the same level, add constraint to parent
-            superview!.addConstraint(constraint)
-            return constraint
-        }
-
-        if view == superview {
-            view.addConstraint(constraint)
-            return constraint
-        }
-
-        if view.superview == self {
-            addConstraint(constraint)
-            return constraint
-        }
-
         guard let commonSuperview = nearestCommonSuperview(with: view) else {
             fatalError("Unable to install constraint on view. Does the constraint reference something from outside the subtree of the view? That's illegal.")
         }

--- a/novoda-constraints/Classes/UIView+Iteration.swift
+++ b/novoda-constraints/Classes/UIView+Iteration.swift
@@ -16,11 +16,16 @@ internal extension Array where Element == UIView {
 
 internal extension UIView {
     func nearestCommonSuperview(with view: UIView) -> UIView? {
+        if view.superview == superview || view == superview {
+            return superview
+        }
+        if view.superview == self {
+            return self
+        }
         return Set(UIView.hierarchy(for: self)).intersection(UIView.hierarchy(for: view)).first
     }
 
     static private func hierarchy(for view: UIView?, accumulator: [UIView] = []) -> [UIView] {
-        print("Checking hierarchy")
         guard let view = view else {
             return accumulator
         }

--- a/novoda-constraints/Classes/UIView+Iteration.swift
+++ b/novoda-constraints/Classes/UIView+Iteration.swift
@@ -13,3 +13,17 @@ internal extension Array where Element == UIView {
         }
     }
 }
+
+internal extension UIView {
+    func nearestCommonSuperview(with view: UIView) -> UIView? {
+        return Set(UIView.hierarchy(for: self)).intersection(UIView.hierarchy(for: view)).first
+    }
+
+    static private func hierarchy(for view: UIView?, accumulator: [UIView] = []) -> [UIView] {
+        print("Checking hierarchy")
+        guard let view = view else {
+            return accumulator
+        }
+        return UIView.hierarchy(for: view.superview, accumulator: accumulator + [view])
+    }
+}


### PR DESCRIPTION
https://github.com/novoda/novoda-constraints/issues/23

This PR allows for constraints in the same subtree but outside of the same parent view to have constraints applied to each other by iterating up to find a common superview.

+ Applies prepare for constraints to both views involved